### PR TITLE
Fix running unit tests on windows

### DIFF
--- a/test.py
+++ b/test.py
@@ -17,6 +17,8 @@ class Test(unittest.TestCase):
     def setUp(self):
         self.dir_data_source = os.path.join(os.path.dirname(__file__), "test", "resources", "2020-skuhrovska-lyze")
         self.dir_data_target = os.path.join(os.path.dirname(__file__), "test", "data", str(random.randrange(1024)).rjust(4, "0"))
+        if os.path.isdir(self.dir_data_target) == True:
+            shutil.rmtree(self.dir_data_target)
         os.makedirs(self.dir_data_target)
         for f in ("athletes.yaml", "clubs.yaml", "event.yaml", "finish.yaml"):
             shutil.copy(os.path.join(self.dir_data_source, f), os.path.join(self.dir_data_target, f))

--- a/test.py
+++ b/test.py
@@ -6,6 +6,7 @@ import shutil
 import subprocess
 import unittest
 import os
+import sys  
 
 class Test(unittest.TestCase):
 
@@ -29,34 +30,34 @@ class Test(unittest.TestCase):
 
     def testAthletesSorted(self):
         """Athletes are sorted correctly"""
-        subprocess.run([os.path.join(os.path.dirname(__file__), "athletes.py")], cwd=self.dir_data_target)
+        subprocess.run([sys.executable, os.path.join(os.path.dirname(__file__), "athletes.py")], cwd=self.dir_data_target)
         self.assertTrue(filecmp.cmp(os.path.join(self.dir_data_source, "athletes-sorted.yaml"), os.path.join(self.dir_data_target, "athletes-sorted.yaml")))
 
     def testStartList(self):
         """Start list is correct"""
-        subprocess.run([os.path.join(os.path.dirname(__file__), "start.py")], cwd=self.dir_data_target)
+        subprocess.run([sys.executable, os.path.join(os.path.dirname(__file__), "start.py")], cwd=self.dir_data_target)
         self.assertTrue(filecmp.cmp(os.path.join(self.dir_data_source, "start.yaml"), os.path.join(self.dir_data_target, "start.yaml")))
 
     def testStartText(self):
         """Start list text file is correct"""
-        subprocess.run([os.path.join(os.path.dirname(__file__), "start.py")], cwd=self.dir_data_target)
+        subprocess.run([sys.executable, os.path.join(os.path.dirname(__file__), "start.py")], cwd=self.dir_data_target)
         self.assertTrue(filecmp.cmp(os.path.join(self.dir_data_source, "start.txt"), os.path.join(self.dir_data_target, "start.txt")))
 
     def testStartClub(self):
         """Start list grouped by club file is correct"""
-        subprocess.run([os.path.join(os.path.dirname(__file__), "start.py"), "--clubs"], cwd=self.dir_data_target)
+        subprocess.run([sys.executable, os.path.join(os.path.dirname(__file__), "start.py"), "--clubs"], cwd=self.dir_data_target)
         self.assertTrue(filecmp.cmp(os.path.join(self.dir_data_source, "start-clubs.txt"), os.path.join(self.dir_data_target, "start-clubs.txt")))
 
     def testResults(self):
         """Result list is correct"""
         shutil.copy(os.path.join(self.dir_data_source, "start.yaml"), os.path.join(self.dir_data_target, "start.yaml"))
-        subprocess.run([os.path.join(os.path.dirname(__file__), "finish.py")], cwd=self.dir_data_target)
+        subprocess.run([sys.executable, os.path.join(os.path.dirname(__file__), "finish.py")], cwd=self.dir_data_target)
         self.assertTrue(filecmp.cmp(os.path.join(self.dir_data_source, "results.yaml"), os.path.join(self.dir_data_target, "results.yaml")))
 
     def testResultsText(self):
         """Result list text file is correct"""
         shutil.copy(os.path.join(self.dir_data_source, "start.yaml"), os.path.join(self.dir_data_target, "start.yaml"))
-        subprocess.run([os.path.join(os.path.dirname(__file__), "finish.py")], cwd=self.dir_data_target)
+        subprocess.run([sys.executable, os.path.join(os.path.dirname(__file__), "finish.py")], cwd=self.dir_data_target)
         self.assertTrue(filecmp.cmp(os.path.join(self.dir_data_source, "results.txt"), os.path.join(self.dir_data_target, "results.txt")))
 
 

--- a/test.py
+++ b/test.py
@@ -17,7 +17,7 @@ class Test(unittest.TestCase):
     def setUp(self):
         self.dir_data_source = os.path.join(os.path.dirname(__file__), "test", "resources", "2020-skuhrovska-lyze")
         self.dir_data_target = os.path.join(os.path.dirname(__file__), "test", "data", str(random.randrange(1024)).rjust(4, "0"))
-        if os.path.isdir(self.dir_data_target) == True:
+        if os.path.isdir(self.dir_data_target):
             shutil.rmtree(self.dir_data_target)
         os.makedirs(self.dir_data_target)
         for f in ("athletes.yaml", "clubs.yaml", "event.yaml", "finish.yaml"):


### PR DESCRIPTION
Pull request contains:
- subprocess on Windows has to contain python executable as argument
- cleanup data directory in setup test stage