### PR TITLE
Align testloop and real usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,11 @@ jobs:
 
       - name: Run ruff check
         run: |
-          uv run ruff check
+          uv run --no-sync ruff check
 
       - name: Run ruff format check
         run: |
-          uv run ruff format --check
+          uv run --no-sync ruff format --check
 
   typechecker:
     runs-on: ubuntu-latest
@@ -35,7 +35,7 @@ jobs:
 
       - name: Run ty check
         run: |
-          uv run ty check --output-format github
+          uv run --no-sync ty check --output-format github
 
   test:
     needs: [lint, typechecker]
@@ -58,4 +58,4 @@ jobs:
         run: uv sync --locked --group test
 
       - name: Run pytest
-        run: uv run pytest
+        run: uv run --no-sync pytest

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 check:
-	uv run ruff check
-	uv run ruff format --check
-	uv run ty check
-	uv run pytest
+	uv run --no-sync ruff check
+	uv run --no-sync ruff format --check
+	uv run --no-sync ty check
+	uv run --no-sync pytest
 
 fix:
-	uv run ruff check --fix
-	uv run ruff format
+	uv run --no-sync ruff check --fix
+	uv run --no-sync ruff format

--- a/README.md
+++ b/README.md
@@ -34,68 +34,29 @@ Hooshek is a command-line interface tool for managing sports competitions, prima
     ```
 
 ## Usage
-<!--
-## Setup competition
 
-1. **Configure the `event.yaml` file with your competition details:**
-
-    ```yaml
-    version: "1.0"
-    name: Skuhrovská Steeplechase
-    date: 2024-09-21
-    encoding_print: "utf_8_sig"
-    mass: true
-    races:
-      - age_min: 0
-        age_max: 3
-        sex: f
-        name: Pulkyně
-        distance: 100m
-    ```
-
-    The `mass` field is used to indicate whether the competition is a mass start.
-
-
-2. **Register athletes by adding them to the `athletes.yaml` file manually:**
-
-    ```yaml
-    athletes:
-    -   born: 2021
-        name: Jiří
-        sex: m
-        surname: Kubsch
-        club: SOSK
-    ```
-    By specifying the `id` field, you can manually assign a bib number to the athlete.
-
-3. **Register athletes by importing them from Czech Ski Association csv file:**
-
+1. **Copy the test folder**
+    The easiest way to start is to copy one of the existing test folders.
     ```bash
-    python register.py --file ./athletes.csv
+    $ cp -r tests/data/2025-skuhrovska-lyze my-folder
+    $ cd my-folder
     ```
 
-## Basic Commands
-
-### Create start list
-
-Create start list of the competition by assigning categories and bib numbers to athletes and create start list.
-
-```bash
-python start.py
-```
-
-### Create final rankings
-
- 1. Enter results of the athlets into finish.yaml file.
-    ```yaml
-    - {id: "J1", time: "00:00:48.6"}
+2. **Generate the start list**
+    ```bash
+    $ uv run --project <PROJECT_PATH> <PROJECT_PATH>/src/hooshek/start.py
     ```
- 2. Run the `finish.py` command to generate the final rankings in txt, csv and json formats. The txt format is the default output format. Use --format option to specify the output format.
+    Check the generated start list at start.yaml and start.txt.
 
-```bash
-python finish.py
-```
--->
+3. **Generate the results**
+    ```bash
+    $ uv run --project <PROJECT_PATH> <PROJECT_PATH>/src/hooshek/finish.py
+    ```
+    Check the generated results at results.yaml and results.txt.
+
+4. **Modify the input and re-run**
+   Modify the input files event.yaml, clubs.yaml, athletes.yaml and finish.yaml as needed.
+   Run start.py, finish.py scripts as above to get the updates.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Hooshek is a command-line interface tool for managing sports competitions, prima
 
 ## Usage
 
-1. **Copy the test folder**
+1. **Copy the test folder**<br>
     The easiest way to start is to copy one of the existing test folders.
     ```bash
     $ cp -r tests/data/2025-skuhrovska-lyze my-folder
@@ -54,7 +54,7 @@ Hooshek is a command-line interface tool for managing sports competitions, prima
     ```
     Check the generated results at results.yaml and results.txt.
 
-4. **Modify the input and re-run**
+4. **Modify the input and re-run**<br>
    Modify the input files event.yaml, clubs.yaml, athletes.yaml and finish.yaml as needed.
    Run start.py, finish.py scripts as above to get the updates.
 

--- a/README.md
+++ b/README.md
@@ -23,11 +23,17 @@ Hooshek is a command-line interface tool for managing sports competitions, prima
     $ uv python install
     ```
 
-4. **Verify the installation**
+4. **Install project dependencies**
+    ```bash
+    $ uv sync --all-groups
+    ```
+
+5. **Verify the installation**
     ```bash
     $ uv run pytest
     ```
 
+## Usage
 <!--
 ## Setup competition
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Hooshek is a command-line interface tool for managing sports competitions, prima
 
 4. **Install project dependencies**
     ```bash
-    $ uv sync --all-groups
+    $ uv sync --locked --all-groups
     ```
 
 5. **Verify the installation**
@@ -44,13 +44,13 @@ Hooshek is a command-line interface tool for managing sports competitions, prima
 
 2. **Generate the start list**
     ```bash
-    $ uv run --project <PROJECT_PATH> <PROJECT_PATH>/src/hooshek/start.py
+    $ uv run --no-sync --project <PROJECT_PATH> <PROJECT_PATH>/src/hooshek/start.py
     ```
     Check the generated start list at start.yaml and start.txt.
 
 3. **Generate the results**
     ```bash
-    $ uv run --project <PROJECT_PATH> <PROJECT_PATH>/src/hooshek/finish.py
+    $ uv run --no-sync --project <PROJECT_PATH> <PROJECT_PATH>/src/hooshek/finish.py
     ```
     Check the generated results at results.yaml and results.txt.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,16 +2,16 @@ import pathlib
 import pytest
 
 
-def dir_fixtures():
+@pytest.fixture(scope="session")
+def project_path():
+    return pathlib.Path(__file__).parents[1]
+
+
+def fixtures_path():
     p = pathlib.Path(__file__).parent / "data"
     return filter(lambda d: d.is_dir(), p.iterdir())
 
 
-@pytest.fixture(params=dir_fixtures(), scope="session")
-def dir_fixture(request):
+@pytest.fixture(params=fixtures_path(), scope="session")
+def fixture_path(request):
     return request.param
-
-
-@pytest.fixture(scope="session")
-def dir_script():
-    return pathlib.Path(__file__).parents[1] / "src" / "hooshek"

--- a/tests/subcommand.py
+++ b/tests/subcommand.py
@@ -1,0 +1,13 @@
+import pathlib
+import subprocess
+
+
+def run(
+    command: list[str], project_path: pathlib.Path, tmp_path: pathlib.Path
+) -> subprocess.CompletedProcess:
+    cmd = (
+        ["uv", "run", "--project", project_path]
+        + [project_path / "src" / "hooshek" / command[0]]
+        + command[1:]
+    )
+    return subprocess.run(cmd, cwd=tmp_path, check=True)

--- a/tests/subcommand.py
+++ b/tests/subcommand.py
@@ -6,7 +6,7 @@ def run(
     command: list[str], project_path: pathlib.Path, tmp_path: pathlib.Path
 ) -> subprocess.CompletedProcess:
     cmd = (
-        ["uv", "run", "--project", project_path]
+        ["uv", "run", "--no-sync", "--project", project_path]
         + [project_path / "src" / "hooshek" / command[0]]
         + command[1:]
     )

--- a/tests/test_athletes.py
+++ b/tests/test_athletes.py
@@ -1,20 +1,20 @@
+import subcommand
+
 import filecmp
 import pytest
-import subprocess
 import shutil
-import sys
 
 
-def test_sort(dir_fixture, dir_script, tmp_path):
-    if not (dir_fixture / "athletes-sorted.yaml").is_file():
+def test_sort(project_path, fixture_path, tmp_path):
+    if not (fixture_path / "athletes-sorted.yaml").is_file():
         pytest.skip("No athletes-sorted.yaml for this fixture")
     for f in ("event.yaml", "clubs.yaml", "athletes.yaml"):
-        shutil.copy(dir_fixture / f, tmp_path)
-    subprocess.run(
-        [sys.executable, dir_script / "athletes.py"], cwd=tmp_path, check=True
-    )
+        shutil.copy(fixture_path / f, tmp_path)
+
+    subcommand.run(["athletes.py"], project_path, tmp_path)
+
     assert filecmp.cmp(
-        dir_fixture / "athletes-sorted.yaml",
+        fixture_path / "athletes-sorted.yaml",
         tmp_path / "athletes-sorted.yaml",
         shallow=False,
     )

--- a/tests/test_export_slcr.py
+++ b/tests/test_export_slcr.py
@@ -1,18 +1,18 @@
+import subcommand
+
 import filecmp
 import pytest
-import subprocess
 import shutil
-import sys
 
 
-def test_export_slcr(dir_fixture, dir_script, tmp_path):
-    if not (dir_fixture / "slcr-export.json").is_file():
+def test_export_slcr(project_path, fixture_path, tmp_path):
+    if not (fixture_path / "slcr-export.json").is_file():
         pytest.skip("No slcr-export.yaml for this fixture")
     for f in ("event.yaml", "clubs.yaml", "athletes.yaml", "start.yaml", "finish.yaml"):
-        shutil.copy(dir_fixture / f, tmp_path)
-    subprocess.run(
-        [sys.executable, dir_script / "export_slcr.py"], cwd=tmp_path, check=True
-    )
+        shutil.copy(fixture_path / f, tmp_path)
+
+    subcommand.run(["export_slcr.py"], project_path, tmp_path)
+
     assert filecmp.cmp(
-        dir_fixture / "slcr-export.json", tmp_path / "slcr-export.json", shallow=False
+        fixture_path / "slcr-export.json", tmp_path / "slcr-export.json", shallow=False
     )

--- a/tests/test_finish.py
+++ b/tests/test_finish.py
@@ -1,14 +1,16 @@
+import subcommand
+
 import filecmp
 import pytest
-import subprocess
 import shutil
-import sys
 
 
 @pytest.mark.parametrize("ext", ("yaml", "txt"))
-def test_finish(dir_fixture, dir_script, tmp_path, ext):
+def test_finish(project_path, fixture_path, tmp_path, ext):
     for f in ("event.yaml", "clubs.yaml", "athletes.yaml", "start.yaml", "finish.yaml"):
-        shutil.copy(dir_fixture / f, tmp_path)
-    subprocess.run([sys.executable, dir_script / "finish.py"], cwd=tmp_path, check=True)
+        shutil.copy(fixture_path / f, tmp_path)
+
+    subcommand.run(["finish.py"], project_path, tmp_path)
+
     filename = "results." + ext
-    assert filecmp.cmp(dir_fixture / filename, tmp_path / filename, shallow=False)
+    assert filecmp.cmp(fixture_path / filename, tmp_path / filename, shallow=False)

--- a/tests/test_numerate.py
+++ b/tests/test_numerate.py
@@ -1,23 +1,23 @@
+import subcommand
+
 import filecmp
 import pytest
-import subprocess
 import shutil
-import sys
 
 
-def test_numerate(dir_fixture, dir_script, tmp_path):
-    if not (dir_fixture / "athletes-without-numbers.yaml").is_file():
+def test_numerate(project_path, fixture_path, tmp_path):
+    if not (fixture_path / "athletes-without-numbers.yaml").is_file():
         pytest.skip("No athletes-without-numbers.yaml for this fixture")
     for f in ("event.yaml", "clubs.yaml"):
-        shutil.copy(dir_fixture / f, tmp_path)
+        shutil.copy(fixture_path / f, tmp_path)
     shutil.copy(
-        dir_fixture / "athletes-without-numbers.yaml", tmp_path / "athletes.yaml"
+        fixture_path / "athletes-without-numbers.yaml", tmp_path / "athletes.yaml"
     )
-    subprocess.run(
-        [sys.executable, dir_script / "numerate.py"], cwd=tmp_path, check=True
-    )
+
+    subcommand.run(["numerate.py"], project_path, tmp_path)
+
     assert filecmp.cmp(
-        dir_fixture / "athletes-with-numbers.yaml",
+        fixture_path / "athletes-with-numbers.yaml",
         tmp_path / "athletes-with-numbers.yaml",
         shallow=False,
     )

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -1,27 +1,29 @@
+import subcommand
+
 import filecmp
 import pytest
-import subprocess
 import shutil
-import sys
 
 
 @pytest.mark.parametrize("ext", ("yaml", "txt"))
-def test_start(dir_fixture, dir_script, tmp_path, ext):
+def test_start(project_path, fixture_path, tmp_path, ext):
     for f in ("event.yaml", "clubs.yaml", "athletes.yaml"):
-        shutil.copy(dir_fixture / f, tmp_path)
-    subprocess.run([sys.executable, dir_script / "start.py"], cwd=tmp_path, check=True)
+        shutil.copy(fixture_path / f, tmp_path)
+
+    subcommand.run(["start.py"], project_path, tmp_path)
+
     filename = "start." + ext
-    assert filecmp.cmp(dir_fixture / filename, tmp_path / filename, shallow=False)
+    assert filecmp.cmp(fixture_path / filename, tmp_path / filename, shallow=False)
 
 
-def test_clubs(dir_fixture, dir_script, tmp_path):
-    if not (dir_fixture / "start-clubs.txt").is_file():
+def test_clubs(project_path, fixture_path, tmp_path):
+    if not (fixture_path / "start-clubs.txt").is_file():
         pytest.skip("No start-clubs.txt for this fixture")
     for f in ("event.yaml", "clubs.yaml", "athletes.yaml"):
-        shutil.copy(dir_fixture / f, tmp_path)
-    subprocess.run(
-        [sys.executable, dir_script / "start.py", "--clubs"], cwd=tmp_path, check=True
-    )
+        shutil.copy(fixture_path / f, tmp_path)
+
+    subcommand.run(["start.py", "--clubs"], project_path, tmp_path)
+
     assert filecmp.cmp(
-        dir_fixture / "start-clubs.txt", tmp_path / "start-clubs.txt", shallow=False
+        fixture_path / "start-clubs.txt", tmp_path / "start-clubs.txt", shallow=False
     )


### PR DESCRIPTION
This PR addresses the discrepancy between the real usage and the testloop commands.
Since there's no way to install the project (yet), we need to ensure the testloop covers the real usage.
It results in verbose commands and unwanted coupling of test sources with uv, but let's not consider it a final solution.

Going forward, we'll need to explore how to build the project, publish it, install it and use it.