### PR TITLE
ClubsModel improvements

### DIFF
--- a/src/hooshek/clubs/repo.py
+++ b/src/hooshek/clubs/repo.py
@@ -20,11 +20,16 @@ class ClubModel(pydantic.BaseModel):
         max_length=15, description="Club name abbreviation to 15 chars max"
     )
     is_sokol: bool = pydantic.Field(
-        default=False, alias="isSokol", description="Is club a member of sokol.eu?"
+        default=False,
+        alias="isSokol",
+        strict=False,
+        description="Is club a member of sokol.eu?",
     )
 
 
 class ClubsModel(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(extra="forbid", strict=True)
+
     version: typing.Literal["1.0"]
     clubs: list[ClubModel]
 
@@ -43,10 +48,7 @@ def load() -> dict[str, Club]:
     raw = yaml.load("clubs.yaml")
     try:
         validated = ClubsModel(**raw)
-        return {
-            club.id: Club(club.id, club.name, club.abb15, club.is_sokol)
-            for club in validated.clubs
-        }
+        return {club.id: Club(**club.model_dump()) for club in validated.clubs}
     except pydantic.ValidationError as e:
         print(e.errors())
         raise

--- a/tests/test_clubs.py
+++ b/tests/test_clubs.py
@@ -1,35 +1,30 @@
-from hooshek.clubs.repo import ClubsModel, load
+from hooshek.clubs.repo import ClubModel, ClubsModel, load
 
 import pytest
 import pydantic
 
 
 def test_valid_clubs_model():
-    data = {
-        "version": "1.0",
-        "clubs": [
-            {"id": "ABCD", "name": "Test Club 1", "abb15": "Test1", "isSokol": True},
-            {"id": "EFGH", "name": "Test Club 2", "abb15": "Test2", "isSokol": False},
-        ],
-    }
+    c1 = {"id": "ABCD", "name": "Club 1", "abb15": "C1"}
+    c2 = {"id": "EFGH", "name": "Club 2", "abb15": "C2", "isSokol": True}
+    data = {"version": "1.0", "clubs": [ClubModel(**c1), ClubModel(**c2)]}
     model = ClubsModel(**data)
     assert model.version == "1.0"
     assert len(model.clubs) == 2
     assert model.clubs[0].id == "ABCD"
-    assert model.clubs[0].is_sokol is True
+    assert model.clubs[0].name == "Club 1"
+    assert model.clubs[0].abb15 == "C1"
+    assert model.clubs[0].is_sokol is False
     assert model.clubs[1].id == "EFGH"
-    assert model.clubs[1].is_sokol is False
+    assert model.clubs[1].name == "Club 2"
+    assert model.clubs[1].abb15 == "C2"
+    assert model.clubs[1].is_sokol is True
 
 
 def test_invalid_club_id_length():
-    data = {
-        "version": "1.0",
-        "clubs": [
-            {"id": "ABC", "name": "Short ID", "abb15": "Short"},
-        ],
-    }
+    data = {"id": "ABC", "name": "Short ID", "abb15": "Short"}
     with pytest.raises(pydantic.ValidationError):
-        ClubsModel(**data)
+        ClubModel(**data)
 
 
 def test_invalid_club_id_pattern():
@@ -39,53 +34,35 @@ def test_invalid_club_id_pattern():
             {"id": "abcd", "name": "Lowercase ID", "abb15": "Lower"},
         ],
     }
+    data = {"id": "abcd", "name": "Lowercase ID", "abb15": "Lower"}
     with pytest.raises(pydantic.ValidationError):
-        ClubsModel(**data)
+        ClubModel(**data)
 
 
 def test_duplicate_club_ids():
-    data = {
-        "version": "1.0",
-        "clubs": [
-            {"id": "ABCD", "name": "Club 1", "abb15": "C1"},
-            {"id": "ABCD", "name": "Club 2", "abb15": "C2"},
-        ],
-    }
+    c1 = {"id": "ABCD", "name": "Club 1", "abb15": "C1"}
+    c2 = {"id": "ABCD", "name": "Club 2", "abb15": "C2"}
+    data = {"version": "1.0", "clubs": [ClubModel(**c1), ClubModel(**c2)]}
     with pytest.raises(ValueError, match="defined 2 times"):
         ClubsModel(**data)
 
 
 def test_no_name():
-    data = {
-        "version": "1.0",
-        "clubs": [
-            {"id": "ABCD"},
-        ],
-    }
+    data = {"id": "ABCD"}
     with pytest.raises(pydantic.ValidationError):
-        ClubsModel(**data)
+        ClubModel(**data)
 
 
 def test_abb15_max_length():
-    data = {
-        "version": "1.0",
-        "clubs": [
-            {"id": "ABCD", "name": "Club", "abb15": "A" * 16},
-        ],
-    }
+    data = {"id": "ABCD", "name": "Club", "abb15": "A" * 16}
     with pytest.raises(pydantic.ValidationError):
-        ClubsModel(**data)
+        ClubModel(**data)
 
 
 def test_invalid_field():
-    data = {
-        "version": "1.0",
-        "clubs": [
-            {"id": "ABCD", "name": "Club 1", "abb15": "C1", "isSokoll": True},
-        ],
-    }
+    data = {"id": "ABCD", "name": "Club 1", "abb15": "C1", "isSokoll": True}
     with pytest.raises(pydantic.ValidationError):
-        ClubsModel(**data)
+        ClubModel(**data)
 
 
 def test_load_repo(monkeypatch, tmp_path):


### PR DESCRIPTION
In general, this PR contains stuff that should have been in the previous PR already.

- Added ClubsModel configuration to match ClubModel
- Make ClubModel.is_sokol not strict for ty not to fail
- Use pydantic model_dump() to instantiate Club
- In tests, replace ClubsModel with ClubModel where appropriate